### PR TITLE
Adding Shutdown script and Cucumber

### DIFF
--- a/switch2/payload.txt
+++ b/switch2/payload.txt
@@ -13,6 +13,9 @@
 
 #ATTACKMODE SERIAL ECM_ETHERNET # Uncomment for debugging purposes. Faster boot without.
 
+# Adding CPU Throttling to prevent overheating.
+CUCUMBER ENABLED
+
 targetPayload = 0
 i = 0
 
@@ -41,3 +44,13 @@ echo "LED $i 100;sleep 2" > /tmp/tmp && cat /root/udisk/payloads/switch1/payload
 
 sync
 LED $i SOLID
+
+# Adding Shutdown script with bonus "Wait 3 sec, blink twice and shutdown".
+sleep 3
+LED OFF
+LED $i SOLID
+LED OFF
+LED $i SOLID
+LED OFF
+LED $i SOLID
+shutdown 0


### PR DESCRIPTION
Shutdown script will limit the Bashbunny from idling too long after Payload is selected.

Cucumber will throttle the CPU to make it where if person is undecided on payload, it wont get hot.